### PR TITLE
Remove unavailable `windows-2016` OS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: cl.exe shouldn't be found
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019, windows-2022]
+        os: [windows-2019, windows-2022]
         arch: [x86, Win32, x64]
 
         include:
           # Prettier run names.
-          - {os: windows-2016, name: VS 2017}
           - {os: windows-2019, name: VS 2019}
           - {os: windows-2022, name: VS 2022}
 


### PR DESCRIPTION
Hi Egor,

thanks for the nice action. Saves me a lot of time to setup VS.

In this PR I have
- removed the nowadays unavailable `windows-2016` and 
- added the `.github/dependabot.yml` action to check for action updates ones a week.
